### PR TITLE
Setup maven publish

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 
 group = 'com.hulu.ftl'
-version = '0.3.0'
+version = '0.3.1'
 sourceCompatibility = 1.8
 
 task sourcesJar(type: Jar) {
@@ -28,7 +28,6 @@ task sourcesJar(type: Jar) {
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            group = 'com.hulu.ftl'
             artifactId = 'ftl'
             from components.java
             artifact sourcesJar
@@ -42,9 +41,14 @@ publishing {
     }
     repositories {
         maven {
+            credentials {
+                username "$mavenUser"
+                password "$mavenPassword"
+            }
+
             // change URLs to point to your repos, e.g. http://my.org/repo
-            def releasesRepoUrl = "$buildDir/repos/releases"
-            def snapshotsRepoUrl = "$buildDir/repos/snapshots"
+            def releasesRepoUrl = "$mavenRepo/releases"
+            def snapshotsRepoUrl = "$mavenRepo/snapshots"
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
         }
     }
@@ -56,6 +60,6 @@ repositories {
 
 
 dependencies {
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.23'
+    compile('org.yaml:snakeyaml:1.23')
     testCompile('org.springframework.boot:spring-boot-starter-test:2.0.5.RELEASE')
 }


### PR DESCRIPTION
reads publish params from ~/.gradle/gradle.properties file
when committing new changes, bump the version number and ./gradlew publish