### PR TITLE
Remove keys starting with $ from output

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'java'
 apply plugin: 'eclipse'
 
 group = 'com.hulu.ftl'
-version = '0.4.0'
+version = '0.4.1'
 sourceCompatibility = 1.8
 
 task sourcesJar(type: Jar) {

--- a/src/main/java/com/hulu/ftl/formats/Parser.java
+++ b/src/main/java/com/hulu/ftl/formats/Parser.java
@@ -23,7 +23,7 @@ public abstract class Parser {
         for(FTLField field : fields) {
             Object result = postprocess(map.get(field.key), map);
             map.put(field.key, result);
-            if (field.key.startsWith("_"))
+            if (field.key.startsWith("$"))
                 map.remove(field.key);
         }
 
@@ -56,7 +56,7 @@ public abstract class Parser {
             for (Object item : valueMap.entrySet()) {
                 Map.Entry entry = (Map.Entry)item;
                 valueMap.put(entry.getKey(), postprocess(entry.getValue(), valueMap));
-                if (entry.getKey().toString().startsWith("_")) {
+                if (entry.getKey().toString().startsWith("$")) {
                     valueMap.remove(entry.getKey());
                 }
             }

--- a/src/main/java/com/hulu/ftl/formats/Parser.java
+++ b/src/main/java/com/hulu/ftl/formats/Parser.java
@@ -23,6 +23,8 @@ public abstract class Parser {
         for(FTLField field : fields) {
             Object result = postprocess(map.get(field.key), map);
             map.put(field.key, result);
+            if (field.key.startsWith("_"))
+                map.remove(field.key);
         }
 
 
@@ -54,6 +56,9 @@ public abstract class Parser {
             for (Object item : valueMap.entrySet()) {
                 Map.Entry entry = (Map.Entry)item;
                 valueMap.put(entry.getKey(), postprocess(entry.getValue(), valueMap));
+                if (entry.getKey().toString().startsWith("_")) {
+                    valueMap.remove(entry.getKey());
+                }
             }
             return valueMap;
         }

--- a/src/main/resources/program.ftl
+++ b/src/main/resources/program.ftl
@@ -1,12 +1,11 @@
 entity_type: !map
-    - tms_id
+    - _tms_id
     -   EP.*: episode
         SH.*: series
         MV.*: movie
-
+_tms_id: TMSId
 
 id: TMSId
-tms_id: TMSId
 root_id: rootId
 fallback: nope|rootId
 connector_id: connectorId

--- a/src/main/resources/program.ftl
+++ b/src/main/resources/program.ftl
@@ -1,9 +1,9 @@
 entity_type: !map
-    - _tms_id
+    - $tms_id
     -   EP.*: episode
         SH.*: series
         MV.*: movie
-_tms_id: TMSId
+$tms_id: TMSId
 
 id: TMSId
 root_id: rootId


### PR DESCRIPTION
Allows us to use temp variables without worrying about them showing up in the output